### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         run: node .github/generate-test-steps.js >> "$GITHUB_OUTPUT"
   
   javascript:
-    name: JavaScript (${{ matrix.example.name }})
+    name: JavaScript / ${{ matrix.example.name }}
     needs: all
     runs-on: ubuntu-latest
     strategy:
@@ -37,7 +37,7 @@ jobs:
         working-directory: ${{ matrix.example.directory }}
 
   kotlin:
-    name: Kotlin (${{ matrix.example.name }})
+    name: Kotlin / ${{ matrix.example.name }}
     needs: all
     runs-on: ubuntu-latest
     strategy:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,6 @@ javascript/dinger-starter         @blackgirlbytes
 javascript/fan-club-credential    @nitro-neal
 javascript/kcc-prototype-exemplar @KendallWeihe
 javascript/pfi-aud-usd-tbdex      @michaelneale
-javascript/pfi-guide-example      @chris-tbd
 javascript/shared-todo            @acekyd
 javascript/shared-todo-starter    @acekyd
 javascript/tbdex-pfi-exemplar     @michaelneale @mistermoe @phoebe-lew @jiyoontbd @kirahsapong

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,7 +11,7 @@ javascript/pfi-guide-example      @chris-tbd
 javascript/shared-todo            @acekyd
 javascript/shared-todo-starter    @acekyd
 javascript/tbdex-pfi-exemplar     @michaelneale @mistermoe @phoebe-lew @jiyoontbd @kirahsapong
-javascript/todo                   @dayhaysoos
-javascript/todo-starter           @dayhaysoos
+javascript/todo                   @acekyd @blackgirlbytes
+javascript/todo-starter           @acekyd @blackgirlbytes
 kotlin/tbdex-example-android      @michaelneale @jiyoontbd
 swift/tbdex-example-ios           @kirahsapong

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # any files outside of examples, and examples that don't yet have a codeowner
 *                                 @finn-tbd
 
-javascript/book-reviews           @acekyd
+javascript/book-reviews           @acekyd @angiejones 
 javascript/dinger                 @blackgirlbytes
 javascript/dinger-starter         @blackgirlbytes
 javascript/fan-club-credential    @nitro-neal

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,7 @@
 javascript/book-reviews           @acekyd @angiejones 
 javascript/dinger                 @blackgirlbytes
 javascript/dinger-starter         @blackgirlbytes
-javascript/fan-club-credential    @nitro-neal
+javascript/fan-club-credential    @nitro-neal @blackgirlbytes
 javascript/kcc-prototype-exemplar @KendallWeihe
 javascript/pfi-aud-usd-tbdex      @michaelneale
 javascript/shared-todo            @acekyd

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,8 @@ javascript/pfi-aud-usd-tbdex      @michaelneale
 javascript/pfi-guide-example      @chris-tbd
 javascript/shared-todo            @acekyd
 javascript/shared-todo-starter    @acekyd
-javascript/tbdex-pfi-exemplar     @michaelneale
+javascript/tbdex-pfi-exemplar     @michaelneale @mistermoe @phoebe-lew @jiyoontbd @kirahsapong
 javascript/todo                   @dayhaysoos
 javascript/todo-starter           @dayhaysoos
-kotlin/tbdex-example-android      @michaelneale
+kotlin/tbdex-example-android      @michaelneale @jiyoontbd
+swift/tbdex-example-ios           @kirahsapong

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,16 @@
+# any files outside of examples, and examples that don't yet have a codeowner
+*                                 @finn-tbd
+
+javascript/book-reviews           @acekyd
+javascript/dinger                 @blackgirlbytes
+javascript/dinger-starter         @blackgirlbytes
+javascript/fan-club-credential    @nitro-neal
+javascript/kcc-prototype-exemplar @KendallWeihe
+javascript/pfi-aud-usd-tbdex      @michaelneale
+javascript/pfi-guide-example      @chris-tbd
+javascript/shared-todo            @acekyd
+javascript/shared-todo-starter    @acekyd
+javascript/tbdex-pfi-exemplar     @michaelneale
+javascript/todo                   @dayhaysoos
+javascript/todo-starter           @dayhaysoos
+kotlin/tbdex-example-android      @michaelneale


### PR DESCRIPTION
This repo is a collection of TBD examples from across our github. Most of them didn't have codeowners, so I've had to guess who was a good contact for each one. If you're listed, please let me know if you are a good codeowner for that example and if there should be any additional codeowners for it. I'll merge when I get confirmation from everyone.

* [x] `javascript/book-reviews` @acekyd @angiejones
* [x] `javascript/dinger` @blackgirlbytes - note this is the code [from the examples folder in developer.tbd.website](https://github.com/TBD54566975/developer.tbd.website/tree/main/examples/tutorials/dinger-completed), _not_ [TBD54566975/dinger](https://github.com/TBD54566975/dinger).
* [x] `javascript/dinger-starter` @blackgirlbytes 
* [x] `javascript/fan-club-credential` @nitro-neal
* [x] `javascript/kcc-prototype-exemplar` @KendallWeihe
* [x] `javascript/pfi-aud-usd-tbdex` @michaelneale
* [x] `javascript/shared-todo` @acekyd 
* [x] `javascript/shared-todo-starter` @acekyd 
* [x] `javascript/tbdex-pfi-exemplar` @michaelneale 
* [x] `javascript/todo` @acekyd @blackgirlbytes
* [x] `javascript/todo-starter` @acekyd @blackgirlbytes
* [x] `kotlin/tbdex-example-android` @michaelneale 
* [x] `swift/tbdex-example-ios` - @kirahsapong