### PR TITLE
Add take action to auto assign contributors for Hacktoberfest

### DIFF
--- a/.github/workflows/take.yml
+++ b/.github/workflows/take.yml
@@ -1,0 +1,26 @@
+name: Auto-assign issue to contributor
+on:
+  issue_comment:
+
+jobs:
+  assign:
+    name: Take an issue
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    if: ${{ github.event.created_at >= format('{0}-10-01T00:00:00Z', github.event.created_at.substr(0,4)) && github.event.created_at <= format('{0}-10-31T23:59:59Z', github.event.created_at.substr(0,4)) }}
+    steps:
+    - name: take the issue
+      uses: bdougie/take-action@main
+      with:
+        message: Thanks for taking this issue! Let us know if you have any questions!
+        trigger: .take
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+  log_out_of_october:
+    name: Log when outside October
+    runs-on: ubuntu-latest
+    if: ${{ !(github.event.created_at >= format('{0}-10-01T00:00:00Z', github.event.created_at.substr(0,4)) && github.event.created_at <= format('{0}-10-31T23:59:59Z', github.event.created_at.substr(0,4))) }}
+    steps:
+    - name: Log skipped action
+      run: echo "Action skipped because the current date is not in October."

--- a/.github/workflows/take.yml
+++ b/.github/workflows/take.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ github.event.created_at >= format('{0}-10-01T00:00:00Z', github.event.created_at.substr(0,4)) && github.event.created_at <= format('{0}-10-31T23:59:59Z', github.event.created_at.substr(0,4)) }}
     steps:
     - name: take the issue
-      uses: bdougie/take-action@main
+      uses: bdougie/take-action@1439165ac45a7461c2d89a59952cd7d941964b87
       with:
         message: Thanks for taking this issue! Let us know if you have any questions!
         trigger: .take


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically assign issues to contributors based on comments, specifically during the month of October. It also includes a logging mechanism for actions taken outside of October.

New GitHub Actions workflow:

* [`.github/workflows/take.yml`](diffhunk://#diff-d3e004796efd8aa465cf8563e767fe5d2f555267902130b8fe4565df1bc1a77fR1-R26): Added a workflow named "Auto-assign issue to contributor" that triggers on issue comments. It assigns an issue to a contributor if the comment is made in October and logs a message if the comment is made outside of October.