### PR TITLE
Adding declaration file for AboutView page

### DIFF
--- a/javascript/dwa-starter-vue/src/views/AboutView.d.ts
+++ b/javascript/dwa-starter-vue/src/views/AboutView.d.ts
@@ -1,0 +1,4 @@
+declare module '@/views/AboutView.vue' {
+  import Vue from 'vue';
+  export default Vue;
+}


### PR DESCRIPTION
I merged a contributor's PR that seemed to have passing tests, but once merged the tests failed. It complained that there's no declaration for the AboutView page. This PR should fix that.
