### PR TITLE
dwa-starter-react-vite: increase maximumFileSizeToCacheInBytes 3mb->5mb

### DIFF
--- a/javascript/dwa-starter-react-vite/vite.config.ts
+++ b/javascript/dwa-starter-react-vite/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
       },
 
       injectManifest: {
-        maximumFileSizeToCacheInBytes: 3000000,
+        maximumFileSizeToCacheInBytes: 5000000,
         globPatterns: ["**/*.{js,css,html,json,svg,png,ico}"],
       },
 


### PR DESCRIPTION
Fix for #159 